### PR TITLE
Bump docker image build

### DIFF
--- a/.github/workflows/github-packages.yml
+++ b/.github/workflows/github-packages.yml
@@ -20,21 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Inspect builder
-        run: |
-          echo "Name:      ${{ steps.buildx.outputs.name }}"
-          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
-          echo "Status:    ${{ steps.buildx.outputs.status }}"
-          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
-          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -48,7 +33,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/${{ github.repository }}/ghcr-test:${{ github.sha }}
 
       - name: Image digest

--- a/.github/workflows/tests-and-checks.yml
+++ b/.github/workflows/tests-and-checks.yml
@@ -16,3 +16,5 @@ jobs:
     steps:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: 1.20.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,7 @@ RUN go test -v ./...
 FROM scratch
 USER 1000:1000
 COPY --from=0 /go/src/github.com/pmarques/ifconfig.me .
+
 EXPOSE 80
+
 ENTRYPOINT ["/ifconfig.me"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.7
+FROM golang:1.20.7-alpine
 
 WORKDIR /go/src/github.com/pmarques/ifconfig.me/
 COPY . /go/src/github.com/pmarques/ifconfig.me/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM golang:1.20.7-alpine
 
 WORKDIR /go/src/github.com/pmarques/ifconfig.me/
-COPY . /go/src/github.com/pmarques/ifconfig.me/
+COPY go.mod /go/src/github.com/pmarques/ifconfig.me/
+RUN go mod download
 
 ARG CGO_ENABLED=0
 ARG GOOS=linux
 ARG GOARCH=arm64
+
+COPY . /go/src/github.com/pmarques/ifconfig.me/
 RUN go build -installsuffix cgo -o ifconfig.me app/main.go
 
 RUN go test -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM golang:1.20.7-alpine
 WORKDIR /go/src/github.com/pmarques/ifconfig.me/
 COPY . /go/src/github.com/pmarques/ifconfig.me/
 
-RUN CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -o ifconfig.me app/main.go
+ARG CGO_ENABLED=0
+ARG GOOS=linux
+ARG GOARCH=arm64
+RUN go build -installsuffix cgo -o ifconfig.me app/main.go
 
 RUN go test -v ./...
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,13 @@ WORKDIR /go/src/github.com/pmarques/ifconfig.me/
 COPY go.mod /go/src/github.com/pmarques/ifconfig.me/
 RUN go mod download
 
+COPY . /go/src/github.com/pmarques/ifconfig.me/
+RUN go test -v ./...
+
 ARG CGO_ENABLED=0
 ARG GOOS=linux
 ARG GOARCH=arm64
-
-COPY . /go/src/github.com/pmarques/ifconfig.me/
 RUN go build -installsuffix cgo -o ifconfig.me app/main.go
-
-RUN go test -v ./...
 
 FROM scratch
 USER 1000:1000


### PR DESCRIPTION
# Description

Remove buildx which was slowing down the build. The drawback at this point is that the resulting image is now marked as amd64 even tho is arm64.