### PR TITLE
Remove CodeQL from push to master

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,8 +6,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [master]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]


### PR DESCRIPTION
# Description

It runs on PRs and on a schedule and the push master is kinda redundant, only useful if the PR is open for too long.