### PR TITLE
Improve readability

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -81,7 +81,7 @@ func main() {
 		}
 		b, err := json.Marshal(e)
 		if err != nil {
-			fmt.Println("error:", err)
+			log.Printf("Error marshalling JSON for not found response (URL: %s): %v", req.URL.Path, err)
 			http.Error(res, "Internal server Error", 500)
 			return
 		}

--- a/handlers/ip/ip_test.go
+++ b/handlers/ip/ip_test.go
@@ -48,9 +48,9 @@ func TestHandlerYaml(t *testing.T) {
 		t.Error("Expected HTTP status code 501, got [", w.Code, "]")
 	}
 
-	if `Encoding responso to [yaml] is not implemented
+	if `Encoding response to [yaml] is not implemented
 ` != w.Body.String() {
-		t.Error(`Expected "Encoding responso to [yaml] is not implemented", got `, w.Body.String())
+		t.Error(`Expected "Encoding response to [yaml] is not implemented", got `, w.Body.String())
 	}
 }
 
@@ -65,9 +65,10 @@ func TestHandlerIPParseError(t *testing.T) {
 		t.Error("Expected HTTP status code 500, got [", w.Code, "]")
 	}
 
-	if `Error parsing remote address [123]
+	if `Error retrieving client IP
 ` != w.Body.String() {
-		t.Error(`Expected "Error parsing remote address [123]", got [`, w.Body.String(), "]")
+		t.Error(`Expected "Error retrieving client IP
+", got [`, w.Body.String(), "]")
 	}
 }
 


### PR DESCRIPTION
Refactor: Improve code readability in request handlers and main app
This commit introduces several changes to improve the overall readability and maintainability of the codebase.

Key changes include:

- In `handlers/ip/ip.go`:
    - Extracted IP address retrieval logic into a new private helper function `getClientIP` to simplify the main `Handler` function.
    - Introduced constants (`formatJSON`, `formatXML`) for response encoding types to avoid raw string literals and reduce the risk of typos.

- In `app/main.go`:
    - Enhanced error logging in the default HTTP handler. Switched from `fmt.Println` to `log.Printf` for marshalling errors to ensure consistency with application logging practices and provide more contextual information.

- In ‘ handlers/ip’:
    - `TestHandlerYaml`: Updated the expected error message to fix a typo ("responso" to "response").
    - `TestHandlerIPParseError`: Modified the expected error message to align with the error now returned by the refactored IP address retrieval logic. The handler now returns a more generic "Error retrieving client IP" when the underlying IP parsing fails.


The OpenTelemetry setup in `app/main.go` was reviewed and deemed sufficiently clear, so no changes were made there.