### PR TITLE
Ignore semgrep rules

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -100,5 +100,6 @@ func main() {
 	bindAddr := fmt.Sprintf("%s:%d", *listenAddr, *listenPort)
 	fmt.Println(`Start listening at "` + bindAddr + `"`)
 
+	// nosemgrep: use-tls
 	log.Fatal(http.ListenAndServe(bindAddr, nil))
 }

--- a/handlers/ip/ip.go
+++ b/handlers/ip/ip.go
@@ -64,6 +64,7 @@ func Handler(res http.ResponseWriter, req *http.Request) {
 			"Content-type", "application/xml",
 		)
 
+		// nosemgrep: no-io-writestring-to-responsewriter
 		io.WriteString(res, xml.Header)
 		enc := xml.NewEncoder(res)
 		enc.Indent("  ", "    ")


### PR DESCRIPTION
# Description

* No intention to use HTTPs in the service at the moment
* HTTP Request output is intended to be a pure txt and no need for extra html template at this point